### PR TITLE
fix (RobVehicle)

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -348,22 +348,30 @@ function RobVehicle(target)
     TaskPlayAnim(target, "mp_am_hold_up", "holdup_victim_20s", 8.0, -8.0, -1, 2, 0, false, false, false)
     QBCore.Functions.Progressbar("rob_keys", "Attemping Robbery..", 6000, false, true, {}, {}, {}, {}, function()
         local chance = math.random(1, 100)
-        if chance > 85 then
-            ClearPedTasksImmediately(target)
-            TaskLeaveVehicle(target, GetVehiclePedIsUsing(target), 256)
-            TaskSmartFleePed(target, PlayerPedId(), 40.0, 20000)
-            local plate = GetVehicleNumberPlateText(GetVehiclePedIsIn(target, true))
-            IsRobbing = false
-            TriggerServerEvent('hud:server:GainStress', math.random(1, 4))
-            TriggerEvent('vehiclekeys:client:SetOwner', plate)
-            QBCore.Functions.Notify('You Got The Keys!', 'success')
-        else
+        if chance > Config.policeCallChance then
             PoliceCall()
             TriggerServerEvent('hud:server:GainStress', math.random(1, 4))
             TaskSmartFleePed(target, PlayerPedId(), 40.0, 20000)
             QBCore.Functions.Notify('They Called The Cops!', 'error')
             Wait(2000)
             IsRobbing = false
+        else
+            local plate = GetVehicleNumberPlateText(GetVehiclePedIsIn(target, true)) -- Fetch vehicle plate
+            Citizen.Wait(0) -- idk if this is redundant
+            TaskLeaveVehicle(target, GetVehiclePedIsUsing(target), 256) -- Leave vehicle with door open
+            while IsPedInAnyVehicle(target, false) do -- Wait until ped is out
+
+                Citizen.Wait(0)
+            end
+
+            ClearPedTasksImmediately(target) -- Cleared ped tasks after they get out of the vehicle
+            ResetPedLastVehicle(target) -- Make them forget what car they were in
+            TaskSmartFleePed(target, PlayerPedId(), 40.0, 20000) -- Make em flee
+
+            IsRobbing = false
+            TriggerServerEvent('hud:server:GainStress', math.random(1, 4))
+            TriggerEvent('vehiclekeys:client:SetOwner', plate)
+            QBCore.Functions.Notify('You Got The Keys!', 'success')
         end
     end)
 end

--- a/config.lua
+++ b/config.lua
@@ -30,3 +30,6 @@ Config.NoRobWeapons = {
     "WEAPON_Snowball",
     "WEAPON_SmokeGrenade",
 }
+
+-- The roll is based on 1-100, by default if it rolls 55 or above police are called.
+Config.policeCallChance = 55;


### PR DESCRIPTION
I changed the RobVehicle function, they don't tp out with the door closed now and there was an issue when successfully robbing vehicles it still didn't give you the keys.

Changes:
- Fixed an issue where they would sometimes get back into the vehicle for fleeing.
- Changed the random chance to be 45% chance of immediately calling the cops and Driving off.
- Fixed a visual issue where the getting out of the car animation would not complete and they would just phase out of the vehicle.

Notable issues:
- Unless you're front on to the vehicle the peds may still drive off while you're robbing them, IDK what to do about that
- Carrying on from the previous issue, when the ped drives off the progress bar does not cancel and the rob complete function will execute when they are far away.
- Can attempt to rob the same vehicle again after they drive away ( as they are driving away ). A possible solution would be storing the plates on the server-side and implementing a client-side check?
