### PR TITLE
Removing VehicleList loops

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -16,10 +16,10 @@ RegisterServerEvent('vehiclekeys:server:SetVehicleOwner')
 AddEventHandler('vehiclekeys:server:SetVehicleOwner', function(plate)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
-    if VehicleList ~= nil then
+    if VehicleList then
         -- VehicleList exists so check for a plate
         local val = VehicleList[plate]
-        if val ~= nil then
+        if val then
             -- The plate exists
             VehicleList[plate].owners[Player.PlayerData.citizenid] = true
         else

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,16 +1,9 @@
 local VehicleList = {}
 
 QBCore.Functions.CreateCallback('vehiclekeys:CheckOwnership', function(source, cb, plate)
-    local retval = false
-    if next(VehicleList) ~= nil then
-        for k,v in pairs(VehicleList) do
-            if v.plate == plate then
-                retval = true
-            else
-                retval = false
-            end
-        end
-    end
+    local check = VehicleList[plate]
+    local retval = check ~= nil
+
     cb(retval)
 end)
 
@@ -24,27 +17,21 @@ AddEventHandler('vehiclekeys:server:SetVehicleOwner', function(plate)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     if VehicleList ~= nil then
-        if DoesPlateExist(plate) then
-            for k, val in pairs(VehicleList) do
-                if val.plate == plate then
-                    table.insert(VehicleList[k].owners, Player.PlayerData.citizenid)
-                end
-            end
+        local val = VehicleList[plate]
+        if val ~= nil then
+            VehicleList[plate].owners[Player.PlayerData.citizenid] = true
         else
-            local vehicleId = #VehicleList+1
-            VehicleList[vehicleId] = {
-                plate = plate, 
-                owners = {},
+            VehicleList[plate] = {
+                owners = {}
             }
-            VehicleList[vehicleId].owners[1] = Player.PlayerData.citizenid
+            VehicleList[plate].owners[Player.PlayerData.citizenid] = true
         end
     else
-        local vehicleId = #VehicleList+1
-        VehicleList[vehicleId] = {
-            plate = plate, 
-            owners = {},
+        VehicleList = {}
+        VehicleList[plate] = {
+            owners = {}
         }
-        VehicleList[vehicleId].owners[1] = Player.PlayerData.citizenid
+        VehicleList[plate].owners[Player.PlayerData.citizenid] = true
     end
 end)
 
@@ -76,29 +63,23 @@ QBCore.Commands.Add("givecarkeys", "Give Car Keys", {{name = "id", help = "Playe
 end)
 
 function DoesPlateExist(plate)
+    local retval = false
     if VehicleList ~= nil then
-        for k, val in pairs(VehicleList) do
-            if val.plate == plate then
-                return true
-            end
-        end
+        local found = VehicleList[plate]
+        retval = found ~= nil
     end
-    return false
+    return retval
 end
 
 function CheckOwner(plate, identifier)
     local retval = false
     if VehicleList ~= nil then
-        for k, val in pairs(VehicleList) do
-            if val.plate == plate then
-                for key, owner in pairs(VehicleList[k].owners) do
-                    if owner == identifier then
-                        retval = true
-                    end
-                end
-            end
+        local found = VehicleList[plate]
+        if found ~= nil then
+            retval = found.owners[identifier] ~= nil or found.owners[identifier] == true
         end
     end
+
     return retval
 end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -17,16 +17,20 @@ AddEventHandler('vehiclekeys:server:SetVehicleOwner', function(plate)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     if VehicleList ~= nil then
+        -- VehicleList exists so check for a plate
         local val = VehicleList[plate]
         if val ~= nil then
+            -- The plate exists
             VehicleList[plate].owners[Player.PlayerData.citizenid] = true
         else
+            -- Plate not currently tracked so store a new one with one owner
             VehicleList[plate] = {
                 owners = {}
             }
             VehicleList[plate].owners[Player.PlayerData.citizenid] = true
         end
     else
+        -- Initialize new VehicleList
         VehicleList = {}
         VehicleList[plate] = {
             owners = {}
@@ -61,15 +65,6 @@ QBCore.Commands.Add("givecarkeys", "Give Car Keys", {{name = "id", help = "Playe
     local target = tonumber(args[1])
     TriggerClientEvent('vehiclekeys:client:GiveKeys', src, target)
 end)
-
-function DoesPlateExist(plate)
-    local retval = false
-    if VehicleList ~= nil then
-        local found = VehicleList[plate]
-        retval = found ~= nil
-    end
-    return retval
-end
 
 function CheckOwner(plate, identifier)
     local retval = false

--- a/server/main.lua
+++ b/server/main.lua
@@ -66,12 +66,12 @@ QBCore.Commands.Add("givecarkeys", "Give Car Keys", {{name = "id", help = "Playe
     TriggerClientEvent('vehiclekeys:client:GiveKeys', src, target)
 end)
 
-function CheckOwner(plate, identifier)
+function CheckOwner1(plate, identifier)
     local retval = false
     if VehicleList then
         local found = VehicleList[plate]
         if found then
-            retval = found.owners[identifier] or found.owners[identifier] == true
+            retval = found.owners[identifier] ~= nil and found.owners[identifier]
         end
     end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -68,10 +68,10 @@ end)
 
 function CheckOwner(plate, identifier)
     local retval = false
-    if VehicleList ~= nil then
+    if VehicleList then
         local found = VehicleList[plate]
-        if found ~= nil then
-            retval = found.owners[identifier] ~= nil or found.owners[identifier] == true
+        if found then
+            retval = found.owners[identifier] or found.owners[identifier] == true
         end
     end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -66,7 +66,7 @@ QBCore.Commands.Add("givecarkeys", "Give Car Keys", {{name = "id", help = "Playe
     TriggerClientEvent('vehiclekeys:client:GiveKeys', src, target)
 end)
 
-function CheckOwner1(plate, identifier)
+function CheckOwner(plate, identifier)
     local retval = false
     if VehicleList then
         local found = VehicleList[plate]

--- a/server/main.lua
+++ b/server/main.lua
@@ -14,28 +14,32 @@ end)
 
 RegisterServerEvent('vehiclekeys:server:SetVehicleOwner')
 AddEventHandler('vehiclekeys:server:SetVehicleOwner', function(plate)
-    local src = source
-    local Player = QBCore.Functions.GetPlayer(src)
-    if VehicleList then
-        -- VehicleList exists so check for a plate
-        local val = VehicleList[plate]
-        if val then
-            -- The plate exists
-            VehicleList[plate].owners[Player.PlayerData.citizenid] = true
+    if plate then
+        local src = source
+        local Player = QBCore.Functions.GetPlayer(src)
+        if VehicleList then
+            -- VehicleList exists so check for a plate
+            local val = VehicleList[plate]
+            if val then
+                -- The plate exists
+                VehicleList[plate].owners[Player.PlayerData.citizenid] = true
+            else
+                -- Plate not currently tracked so store a new one with one owner
+                VehicleList[plate] = {
+                    owners = {}
+                }
+                VehicleList[plate].owners[Player.PlayerData.citizenid] = true
+            end
         else
-            -- Plate not currently tracked so store a new one with one owner
+            -- Initialize new VehicleList
+            VehicleList = {}
             VehicleList[plate] = {
                 owners = {}
             }
             VehicleList[plate].owners[Player.PlayerData.citizenid] = true
         end
     else
-        -- Initialize new VehicleList
-        VehicleList = {}
-        VehicleList[plate] = {
-            owners = {}
-        }
-        VehicleList[plate].owners[Player.PlayerData.citizenid] = true
+        print('vehiclekeys:server:SetVehicleOwner - plate argument is nil')
     end
 end)
 


### PR DESCRIPTION
Replaced access to VehicleList to be done using hashing rather than table.insert(...).
This allows direct access to items without looping and potentially improve performance.

I removed the DoesPlateExist(...) function due the fact the hashing approach is so much simpler and it wasn't really needed. DoesPlateExist actually looped over the entire VehicleList table to return a boolean and then if the result was true it would just loop over the list comparing plates again.

To ensure CheckOwner is returning a boolean only I've left the ~= in place for this single line:
`retval = found.owners[identifier] ~= nil and found.owners[identifier]`

Without that nil check there are cases where nil will be returned. This isn't called in any loops so shouldn't pose an issue. 