### PR TITLE
Update main.lua

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -97,15 +97,22 @@ CreateThread(function()
                                 HasKey = true
                             end
                         else
-                            if not lockpicked and lockpickedPlate ~= plate then
-                                QBCore.Functions.TriggerCallback('vehiclekeys:CheckHasKey', function(result)
+                            QBCore.Functions.TriggerCallback('vehiclekeys:CheckHasKey', function(result)
+                                if not lockpicked and lockpickedPlate ~= plate then
                                     if result == false then
                                         SetVehicleDoorsLocked(entering, 2)
-                                    else
+                                        HasKey = false
+                                    else 
                                         HasKey = true
                                     end
-                                end, plate)
-                            end
+                                elseif lockpicked and lockpickedPlate == plate then
+                                    if result == false then
+                                        HasKey = false
+                                    else 
+                                        HasKey = true
+                                    end
+                                end
+                            end, plate)
                         end
                     end
                 end, plate)


### PR DESCRIPTION
Fix for Issues #44 #45 #52 #53 
Has been tested on my server all seems to work well, players can
 - lockpick and hotwire cars they do not own
 - Get in cars they do own and start no problems
 - Shoot peds out of the drivers seat and get in without having to hotwire
 - Point a gun a ped drivers to start the robbery function, after successful robbery can get in with keys and drive away
 - Not get in or start cars they dont own without lockpicking first

