### PR TITLE
fixing hotwire issue

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -356,7 +356,7 @@ CreateThread(function()
                 sleep = 2000
                 local plate = QBCore.Functions.GetPlate(entering)
                 QBCore.Functions.TriggerCallback('vehiclekeys:server:CheckOwnership', function(result)
-                    if not result then -- if not player owned
+                    if result ~= true then -- if not player owned
                         local driver = GetPedInVehicleSeat(entering, -1)
                         if driver ~= 0 and not IsPedAPlayer(driver) then
                             if Config.Rob then
@@ -365,18 +365,19 @@ CreateThread(function()
                                     SetVehicleDoorsLocked(entering, 1)
                                     HasVehicleKey = true
                                 else
-                                    SetVehicleDoorsLocked(entering, 2)
+                                    SetVehicleDoorsLocked(entering, 1)
+                                    HasVehicleKey = false
                                 end
                             else
                                 TriggerEvent("vehiclekeys:client:SetOwner", plate)
                                 SetVehicleDoorsLocked(entering, 1)
-                                HasVehicleKey = true
+                                HasVehicleKey = false
                             end
                         else
                             QBCore.Functions.TriggerCallback('vehiclekeys:server:CheckHasKey', function(result)
                                 if not lockpicked and lockpickedPlate ~= plate then
                                     if result == false then
-                                        SetVehicleDoorsLocked(entering, 2)
+                                        SetVehicleDoorsLocked(entering, 1)
                                         HasVehicleKey = false
                                     else 
                                         HasVehicleKey = true
@@ -389,12 +390,13 @@ CreateThread(function()
                                     end
                                 end
                             end, plate)
+                            HasVehicleKey = true
                         end
                     end
                 end, plate)
             end
 
-            if IsPedInAnyVehicle(ped, false) and lockpicked and not IsHotwiring and not HasVehicleKey then
+            if IsPedInAnyVehicle(ped, false) and HasVehicleKey ~= true then
                 sleep = 5
                 local veh = GetVehiclePedIsIn(ped)
                 local vehpos = GetOffsetFromEntityInWorldCoords(veh, 0.0, 2.0, 1.0)

--- a/client/main.lua
+++ b/client/main.lua
@@ -356,7 +356,7 @@ CreateThread(function()
                 sleep = 2000
                 local plate = QBCore.Functions.GetPlate(entering)
                 QBCore.Functions.TriggerCallback('vehiclekeys:server:CheckOwnership', function(result)
-                    if result ~= true then -- if not player owned
+                    if not result then -- if not player owned
                         local driver = GetPedInVehicleSeat(entering, -1)
                         if driver ~= 0 and not IsPedAPlayer(driver) then
                             if Config.Rob then

--- a/server/main.lua
+++ b/server/main.lua
@@ -68,10 +68,10 @@ end)
 -- callback
 
 QBCore.Functions.CreateCallback('vehiclekeys:server:CheckOwnership', function(source, cb, plate)
-    local check = VehicleList[plate]
-    local retval = check ~= nil
-
-    cb(retval)
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    local isowner = CheckOwner(plate, Player.PlayerData.citizenid)
+    cb(isowner)
 end)
 
 QBCore.Functions.CreateCallback('vehiclekeys:server:CheckHasKey', function(source, cb, plate)


### PR DESCRIPTION
1. Now if anyone other than the owner takes the vehicle they'll have to hotwire the car. Or if the owner gives them keys then they'll not have to hotwire

2. Even if they lockpick they'll have to hotwire. Because they just lockpicked doors but they'll have to Hotwire regardless.

3. With config rob they'll also get the option to just take the vehicle but they'll not get the key. and will have to hotwire

4. If they rob/kill the driver they'll get the key

Note: If you don't want to keep the door open when config. rob is true then change line 368 SetVehicleDoorsLocked(entering, 1) to SetVehicleDoorsLocked(entering, 2)