### PR TITLE
Allow ignoring locks for certain vehicles

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -352,7 +352,7 @@ CreateThread(function()
         if LocalPlayer.state.isLoggedIn then
             local ped = PlayerPedId()
             local entering = GetVehiclePedIsTryingToEnter(ped)
-            if entering ~= 0 then
+            if entering ~= 0 and not Entity(entering).state.ignoreLocks then
                 sleep = 2000
                 local plate = QBCore.Functions.GetPlate(entering)
                 QBCore.Functions.TriggerCallback('vehiclekeys:server:CheckOwnership', function(result)


### PR DESCRIPTION
In some situations you might want to have always-unlocked vehicles where setting ownership doesnt make sense (i.e. persistent job vehicles, free-to-take bikes, ...)

This allows always-unlocked vehicles with `Entity(entity).state.ignoreLocks = true`