### PR TITLE
fix: breakLockpick doesn't exist in inventory

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -377,11 +377,11 @@ function lockpickFinish(success)
 
     if usingAdvanced then
         if chance <= Config.RemoveLockpickAdvanced then
-            TriggerServerEvent("inventory:server:breakLockpick", "advancedlockpick")
+            TriggerServerEvent("qb-vehiclekeys:server:breakLockpick", "advancedlockpick")
         end
     else
         if chance <= Config.RemoveLockpickNormal then
-            TriggerServerEvent("inventory:server:breakLockpick", "lockpick")
+            TriggerServerEvent("qb-vehiclekeys:server:breakLockpick", "lockpick")
         end
     end
 end

--- a/server/main.lua
+++ b/server/main.lua
@@ -36,6 +36,14 @@ RegisterNetEvent('qb-vehiclekeys:server:AcquireVehicleKeys', function(plate)
     GiveKeys(src, plate)
 end)
 
+RegisterNetEvent('qb-vehiclekeys:server:breakLockpick', function(itemName)
+    local Player = QBCore.Functions.GetPlayer(source)
+    if Player then
+        TriggerClientEvent("inventory:client:ItemBox", source, QBCore.Shared.Items[itemName], "remove")
+        Player.Functions.RemoveItem(itemName, 1)
+    end
+end)
+
 QBCore.Functions.CreateCallback('qb-vehiclekeys:server:GetVehicleKeys', function(source, cb)
     local citizenid = QBCore.Functions.GetPlayer(source).PlayerData.citizenid
     local keysList = {}

--- a/server/main.lua
+++ b/server/main.lua
@@ -38,9 +38,10 @@ end)
 
 RegisterNetEvent('qb-vehiclekeys:server:breakLockpick', function(itemName)
     local Player = QBCore.Functions.GetPlayer(source)
-    if Player then
-        TriggerClientEvent("inventory:client:ItemBox", source, QBCore.Shared.Items[itemName], "remove")
-        Player.Functions.RemoveItem(itemName, 1)
+    if not Player then return end
+    if not (itemName == "lockpick" or itemName == "advancedlockpick") then return end
+    if Player.Functions.RemoveItem(itemName, 1) then
+            TriggerClientEvent("inventory:client:ItemBox", source, QBCore.Shared.Items[itemName], "remove")
     end
 end)
 


### PR DESCRIPTION
**Describe Pull request**
When reviewing the lockpick code to add a new item in my server I found that the breakLockpick event doesn't exist in qb-inventory nor in any other variation of it from what I can find.  This fixes that by moving that event to the vehiclekeys resource and resolving the issue of this event not existing.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)  YES
- Does your code fit the style guidelines? [yes/no] YES
- Does your PR fit the contribution guidelines? [yes/no]  YES
