### PR TITLE
Corrected PoliceAlertChance

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -12,8 +12,8 @@ Config.minHotwireTime = 20000
 Config.maxHotwireTime = 40000
 
 Config.AlertCooldown = 10000 -- 10 seconds
-Config.PoliceAlertChance = 1.75 -- Chance of alerting police during the day
-Config.PoliceNightAlertChance = 1.50 -- Chance of alerting police at night (times:01-06)
+Config.PoliceAlertChance = 0.75 -- Chance of alerting police during the day
+Config.PoliceNightAlertChance = 0.50 -- Chance of alerting police at night (times:01-06)
 
 Config.ImmuneVehicles = { -- These vehicles cannot be jacked
     'stockade'


### PR DESCRIPTION
PoliceAlert chances resulted in the police alert always triggering.

**Describe Pull request**
math.random() results in a number between 0 and 1. With the config being set to 1.75 and 1.50 by default it results in policealert always triggering. 
Changing them to 0.75 and 0.50 respectively resolves the issue

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
