### PR TITLE
feat(client/server): NPC Vehicle Lock state config options and associated logic. Server sided lock state control. Some optimisation

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -40,7 +40,7 @@ CreateThread(function()
                     if IsEntityDead(driver) then
                         if not isTakingKeys then
                             isTakingKeys = true
-                            SetVehicleDoorsLocked(entering, 1)
+                            TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(entering), 1)
                             QBCore.Functions.Progressbar("steal_keys", "Taking keys from body...", 2500, false, false, {
                                 disableMovement = false,
                                 disableCarMovement = true,
@@ -54,9 +54,9 @@ CreateThread(function()
                             end)
                         end
                     elseif Config.LockNPCDrivingCars then
-                        SetVehicleDoorsLocked(entering, 2)
+                        TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(entering), 2)
                     else
-                        SetVehicleDoorsLocked(entering, 1)
+                        TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(entering), 1)
                         TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', plate)
                         local pedsInVehicle = GetPedsInVehicle(entering)
                         for _, pedInVehicle in pairs(pedsInVehicle) do
@@ -66,9 +66,9 @@ CreateThread(function()
                 -- Parked car logic
                 elseif driver == 0 and entering ~= lastPickedVehicle and not HasKeys(plate) and not isTakingKeys then
                     if Config.LockNPCParkedCars then
-                        SetVehicleDoorsLocked(entering, 2)
+                        TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(entering), 2)
                     else
-                        SetVehicleDoorsLocked(entering, 1)
+                        TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(entering), 1)
                     end
                 end
             end
@@ -296,10 +296,10 @@ function ToggleVehicleLocks(veh)
 
                 NetworkRequestControlOfEntity(veh)
                 if vehLockStatus == 1 then
-                    SetVehicleDoorsLocked(veh, 2)
+                    TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(veh), 2)
                     QBCore.Functions.Notify("Vehicle locked!", "primary")
                 else
-                    SetVehicleDoorsLocked(veh, 1)
+                    TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(veh), 1)
                     QBCore.Functions.Notify("Vehicle unlocked!", "success")
                 end
 
@@ -314,7 +314,7 @@ function ToggleVehicleLocks(veh)
                 QBCore.Functions.Notify("You don't have keys to this vehicle.", 'error')
             end
         else
-            SetVehicleDoorsLocked(veh, 1)
+            TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(veh), 1)
         end
     end
 end
@@ -379,7 +379,7 @@ function lockpickFinish(success)
             TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', QBCore.Functions.GetPlate(vehicle))
         else
             QBCore.Functions.Notify('You managed to pick the door lock open!', 'success')
-            SetVehicleDoorsLocked(vehicle, 1)
+            TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', vehicle, 1)
         end
 
     else

--- a/client/main.lua
+++ b/client/main.lua
@@ -58,9 +58,13 @@ CreateThread(function()
                     else
                         TriggerServerEvent('qb-vehiclekeys:server:setVehLockState', NetworkGetNetworkIdFromEntity(entering), 1)
                         TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', plate)
+
+                        --Make passengers flee
                         local pedsInVehicle = GetPedsInVehicle(entering)
                         for _, pedInVehicle in pairs(pedsInVehicle) do
-                            MakePedFlee(pedInVehicle)
+                            if pedInVehicle ~= GetPedInVehicleSeat(entering, -1) then
+                                MakePedFlee(pedInVehicle)
+                            end
                         end
                     end
                 -- Parked car logic

--- a/client/main.lua
+++ b/client/main.lua
@@ -31,10 +31,11 @@ CreateThread(function()
 
                 local driver = GetPedInVehicleSeat(entering, -1)
                 for _, veh in ipairs(Config.ImmuneVehicles) do
-                    if GetEntityModel(entering) == GetHashKey(veh) then
+                    if GetEntityModel(entering) == joaat(veh) then
                         carIsImmune = true
                     end
                 end
+                -- Driven vehicle logic
                 if driver ~= 0 and not IsPedAPlayer(driver) and not HasKeys(plate) and not carIsImmune then
                     if IsEntityDead(driver) then
                         if not isTakingKeys then
@@ -52,11 +53,23 @@ CreateThread(function()
                                 isTakingKeys = false
                             end)
                         end
-                    else
+                    elseif Config.LockNPCDrivingCars then
                         SetVehicleDoorsLocked(entering, 2)
+                    else
+                        SetVehicleDoorsLocked(entering, 1)
+                        TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', plate)
+                        local pedsInVehicle = GetPedsInVehicle(entering)
+                        for _, pedInVehicle in pairs(pedsInVehicle) do
+                            MakePedFlee(pedInVehicle)
+                        end
                     end
+                -- Parked car logic
                 elseif driver == 0 and entering ~= lastPickedVehicle and not HasKeys(plate) and not isTakingKeys then
-                    SetVehicleDoorsLocked(entering, 2)
+                    if Config.LockNPCParkedCars then
+                        SetVehicleDoorsLocked(entering, 2)
+                    else
+                        SetVehicleDoorsLocked(entering, 1)
+                    end
                 end
             end
 
@@ -67,7 +80,7 @@ CreateThread(function()
                 local plate = QBCore.Functions.GetPlate(vehicle)
 
                 if GetPedInVehicleSeat(vehicle, -1) == PlayerPedId() and not HasKeys(plate) and not isBlacklistedVehicle(vehicle) then
-                    sleep = 5
+                    sleep = 0
 
                     local vehiclePos = GetOffsetFromEntityInWorldCoords(vehicle, 0.0, 1.0, 0.5)
                     DrawText3D(vehiclePos.x, vehiclePos.y, vehiclePos.z, "~g~[H]~w~ - Search for Keys")
@@ -79,7 +92,6 @@ CreateThread(function()
                 end
             end
 
-
             if canCarjack then
                 local playerid = PlayerId()
                 local aiming, target = GetEntityPlayerIsFreeAimingAt(playerid)
@@ -87,7 +99,7 @@ CreateThread(function()
                     if DoesEntityExist(target) and IsPedInAnyVehicle(target, false) and not IsEntityDead(target) and not IsPedAPlayer(target) then
                         local targetveh = GetVehiclePedIsIn(target)
                         for _, veh in ipairs(Config.ImmuneVehicles) do
-                            if GetEntityModel(targetveh) == GetHashKey(veh) then
+                            if GetEntityModel(targetveh) == joaat(veh) then
                                 carIsImmune = true
                             end
                         end

--- a/config.lua
+++ b/config.lua
@@ -1,4 +1,6 @@
 Config = {}
+Config.LockNPCDrivingCars = false
+Config.LockNPCParkedCars = false
 Config.HotwireChance = 0.5 -- Chance for successful hotwire or not
 
 Config.RemoveLockpickNormal = 0.5 -- Chance to remove lockpick on fail

--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,6 @@
 Config = {}
-Config.LockNPCDrivingCars = true
-Config.LockNPCParkedCars = true
+Config.LockNPCDrivingCars = true  -- Lock state for NPC cars being driven by NPCs [true = locked, false = unlocked]
+Config.LockNPCParkedCars = true -- Lock state for NPC parked cars [true = locked, false = unlocked]
 Config.HotwireChance = 0.5 -- Chance for successful hotwire or not
 
 Config.RemoveLockpickNormal = 0.5 -- Chance to remove lockpick on fail

--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,6 @@
 Config = {}
-Config.LockNPCDrivingCars = false
-Config.LockNPCParkedCars = false
+Config.LockNPCDrivingCars = true
+Config.LockNPCParkedCars = true
 Config.HotwireChance = 0.5 -- Chance for successful hotwire or not
 
 Config.RemoveLockpickNormal = 0.5 -- Chance to remove lockpick on fail

--- a/server/main.lua
+++ b/server/main.lua
@@ -45,6 +45,10 @@ RegisterNetEvent('qb-vehiclekeys:server:breakLockpick', function(itemName)
     end
 end)
 
+RegisterNetEvent('qb-vehiclekeys:server:setVehLockState', function(vehNetId, state)
+    SetVehicleDoorsLocked(NetworkGetEntityFromNetworkId(vehNetId), state)
+end)
+
 QBCore.Functions.CreateCallback('qb-vehiclekeys:server:GetVehicleKeys', function(source, cb)
     local citizenid = QBCore.Functions.GetPlayer(source).PlayerData.citizenid
     local keysList = {}


### PR DESCRIPTION
**Describe Pull request**
This PR adds config options to allow users to easily set whether NPC cars are locked or unlocked by default.
The default setting remains as both driven and parked NPC cars are locked.
There are also some small optimisations included in this PR.

As requested in #126 and #104 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
