### PR TITLE
fix(client): lua type error

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -196,7 +196,7 @@ RegisterNetEvent('qb-vehiclekeys:client:GiveKeys', function(id)
     if targetVehicle then
         local targetPlate = QBCore.Functions.GetPlate(targetVehicle)
         if HasKeys(targetPlate) then
-            if id ~= nil then -- Give keys to specific ID
+            if id and type(id) == "number" then -- Give keys to specific ID
                 GiveKeys(id, targetPlate)
             else
                 if IsPedSittingInVehicle(PlayerPedId(), targetVehicle) then -- Give keys to everyone in vehicle


### PR DESCRIPTION
**Describe Pull request**
This fixes an error if you pass another type than a number like a table (radialmenu used to do this, so this is basically backwards compatibility)

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
