### PR TITLE
fix(client): Fixes #150

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -436,6 +436,7 @@ function Hotwire(vehicle, plate)
     SetTimeout(10000, function()
         AttemptPoliceAlert("steal")
     end)
+    IsHotwiring = false
 end
 
 function CarjackVehicle(target)


### PR DESCRIPTION
**Describe Pull request**
This PR is a simple fix for the bug described in #150. 

When already in a progress bar, you could still begin the `hotwire()` function, which would set `isHotwiring = true` but it would not run the progress bar code as you would already be in one. The only two options to set `isHotwiring = false` were in the progress bar complete and cancel callbacks. Therefore this PR catches that by setting `isHotwiring = false` after the progressbar code in case it fails to run.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
