### PR TITLE
fix(client/server): Fixes player vehicles locking when no driver present. Fixes #156

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -28,7 +28,6 @@ CreateThread(function()
             if entering ~= 0 and not isBlacklistedVehicle(entering) then
                 sleep = 3000
                 local plate = QBCore.Functions.GetPlate(entering)
-                local enteringEntity = Entity(entering)
                 local driver = GetPedInVehicleSeat(entering, -1)
                 for _, veh in ipairs(Config.ImmuneVehicles) do
                     if GetEntityModel(entering) == joaat(veh) then

--- a/client/main.lua
+++ b/client/main.lua
@@ -37,7 +37,7 @@ CreateThread(function()
                 end
 
                 -- Check if the car we are entering is player owned
-                TriggerServerCallback("qb-vehiclekeys:server:checkPlayerOwned", function(playerOwned)
+                QBCore.Functions.TriggerCallback("qb-vehiclekeys:server:checkPlayerOwned", function(playerOwned)
 
                     -- NPC Driven vehicle logic
                     if driver ~= 0 and not playerOwned and not HasKeys(plate) and not carIsImmune then

--- a/server/main.lua
+++ b/server/main.lua
@@ -12,15 +12,6 @@ local VehicleList = {}
 ---- Server Events ----
 -----------------------
 
--- This event checks if the car is player owned by seeing if any player owns keys for this vehicle
--- If the vehicle is player owned, then we set the playerOwned state bag to true
-RegisterNetEvent("qb-vehiclekeys:server:checkPlayerOwned", function(plate, vehNetId)
-    local vehEntity = Entity(NetworkGetEntityFromNetworkId(vehNetId))
-    if not vehEntity.state.playerOwned and VehicleList[plate] then
-        vehEntity.state.playerOwned = true
-    end
-end)
-
 -- Event to give keys. receiver can either be a single id, or a table of ids.
 -- Must already have keys to the vehicle, trigger the event from the server, or pass forcegive paramter as true.
 RegisterNetEvent('qb-vehiclekeys:server:GiveVehicleKeys', function(receiver, plate)
@@ -67,6 +58,16 @@ QBCore.Functions.CreateCallback('qb-vehiclekeys:server:GetVehicleKeys', function
         end
     end
     cb(keysList)
+end)
+
+-- This Callback checks if the car is player owned by seeing if any player owns keys for this vehicle
+-- If the vehicle is player owned, then we set the playerOwned state bag to true
+QBCore.Functions.CreateCallback("qb-vehiclekeys:server:checkPlayerOwned", function(plate, vehNetId)
+    local vehEntity = Entity(NetworkGetEntityFromNetworkId(vehNetId))
+    if not vehEntity.state.playerOwned and VehicleList[plate] then
+        vehEntity.state.playerOwned = true
+    end
+    return vehEntity.state.playerOwned
 end)
 
 -----------------------

--- a/server/main.lua
+++ b/server/main.lua
@@ -12,6 +12,15 @@ local VehicleList = {}
 ---- Server Events ----
 -----------------------
 
+-- This event checks if the car is player owned by seeing if any player owns keys for this vehicle
+-- If the vehicle is player owned, then we set the playerOwned state bag to true
+RegisterNetEvent("qb-vehiclekeys:server:checkPlayerOwned", function(plate, vehNetId)
+    local vehEntity = Entity(NetworkGetEntityFromNetworkId(vehNetId))
+    if not vehEntity.state.playerOwned and VehicleList[plate] then
+        vehEntity.state.playerOwned = true
+    end
+end)
+
 -- Event to give keys. receiver can either be a single id, or a table of ids.
 -- Must already have keys to the vehicle, trigger the event from the server, or pass forcegive paramter as true.
 RegisterNetEvent('qb-vehiclekeys:server:GiveVehicleKeys', function(receiver, plate)
@@ -69,7 +78,7 @@ function GiveKeys(id, plate)
 
     if not VehicleList[plate] then VehicleList[plate] = {} end
     VehicleList[plate][citizenid] = true
-    
+
     TriggerClientEvent('QBCore:Notify', id, Lang:t("notify.vgetkeys"))
     TriggerClientEvent('qb-vehiclekeys:client:AddKeys', id, plate)
 end


### PR DESCRIPTION
**Describe Pull request**
This PR has been created to address the issue of player vehicles unintentionally becoming locked after the owner leaves the vehicle. The NPC vehicle check logic did not cater for a player owned vehicle and treated any empty vehicle as an NPC vehicle, so when the config option `Config.LockNPCParkedCars` was set to `true` this would lock that vehicle when a player without keys tried to enter the empty vehicle.

Fixes #156 & #159

This requires further testing. The following scenarios should be tested with `Config.LockNPCParkedCars = true`:  

**Scenario 1**  
1. Owner gets out of vehicle while vehicle is unlocked.
2. Other player without keys attempts to get in the vehicle.  

**Expected result**: Both players should be able to enter the unlocked vehicle.

**Scenario 2**  
1. Owner locks vehicle from outside
2. Other player tries to enter. 

**Expected result**: Vehicle should be locked.

**Scenario 3**
1. Owner unlocks vehicle. 
2. Other player tries to enter empty vehicle.

**Expected result**: Vehicle should be unlocked

**Other tests**
- [ ] Lockpicking should remain as it was. (able to enter a vehicle NPC or owned after lock pick success)
- [ ] Config options for NPC cars should work as intended.
- [ ] Alternative config options should not affect Scenario's 1, 2 & 3

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
