### PR TITLE
fix(client): Ensure uppercase comparison

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -301,7 +301,7 @@ function AreKeysJobShared(veh)
         if job == jobName then
 	    if Config.SharedKeys[job].requireOnduty and not onDuty then return false end
 	    for _, vehicle in pairs(v.vehicles) do
-	        if string.upper(vehicle) == vehName then
+	        if string.upper(vehicle) == string.upper(vehName) then
 		    if not HasKeys(vehPlate) then
 		        TriggerServerEvent("qb-vehiclekeys:server:AcquireVehicleKeys", vehPlate)
 		    end


### PR DESCRIPTION
**Describe Pull request**
Fixes an issue reported in https://github.com/qbcore-framework/qb-vehiclekeys/issues/164. Addon vehicles can be created with lowercase characters in the `<modelName>` attribute of the vehicle.meta. Default GTA vehicles return uppercase model names by default. This change protects against that by making sure the comparison is for uppercase.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [no] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
