### PR TITLE
Change to getPlate

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -294,7 +294,7 @@ end
 
 function AreKeysJobShared(veh)
     local vehName = GetDisplayNameFromVehicleModel(GetEntityModel(veh))
-    local vehPlate = GetVehicleNumberPlateText(veh)
+    local vehPlate = QBCore.Functions.GetPlate(veh)
     local jobName = QBCore.Functions.GetPlayerData().job.name
     local onDuty = QBCore.Functions.GetPlayerData().job.onduty
     for job, v in pairs(Config.SharedKeys) do


### PR DESCRIPTION
I had issues with white space when using shorter than 8 character plates. This fixes it. 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest) yes
- Does your code fit the style guidelines? [yes/no] yes 
- Does your PR fit the contribution guidelines? [yes/no] yes 
