### PR TITLE
Preventing vehicles being started when player not inside

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -385,7 +385,7 @@ function GetVehicle()
     local ped = PlayerPedId()
     local pos = GetEntityCoords(ped)
     local vehicle = GetVehiclePedIsIn(PlayerPedId())
-    
+
     while vehicle == 0 do
         vehicle = QBCore.Functions.GetClosestVehicle()
         if #(pos - GetEntityCoords(vehicle)) > 8 then

--- a/client/main.lua
+++ b/client/main.lua
@@ -385,6 +385,7 @@ function GetVehicle()
     local ped = PlayerPedId()
     local pos = GetEntityCoords(ped)
     local vehicle = GetVehiclePedIsIn(PlayerPedId())
+    QBCore.Functions.Notify(Lang:t("notify.vehclose"), "error")
 
     while vehicle == 0 do
         vehicle = QBCore.Functions.GetClosestVehicle()

--- a/client/main.lua
+++ b/client/main.lua
@@ -201,8 +201,12 @@ RegisterCommand('togglelocks', function()
 end)
 RegisterKeyMapping('engine', Lang:t("info.engine"), 'keyboard', 'G')
 RegisterCommand('engine', function()
-    ToggleEngine(GetVehicle())
+    local vehicle = GetVehicle()
+    if vehicle and IsPedInVehicle(PlayerPedId(), vehicle) then
+        ToggleEngine(vehicle)
+    end
 end)
+
 AddEventHandler('onResourceStart', function(resourceName)
     if resourceName == GetCurrentResourceName() and QBCore.Functions.GetPlayerData() ~= {} then
         GetKeys()
@@ -385,7 +389,6 @@ function GetVehicle()
     while vehicle == 0 do
         vehicle = QBCore.Functions.GetClosestVehicle()
         if #(pos - GetEntityCoords(vehicle)) > 8 then
-            QBCore.Functions.Notify(Lang:t("notify.vehclose"), "error")
         return end
     end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -385,12 +385,13 @@ function GetVehicle()
     local ped = PlayerPedId()
     local pos = GetEntityCoords(ped)
     local vehicle = GetVehiclePedIsIn(PlayerPedId())
-    QBCore.Functions.Notify(Lang:t("notify.vehclose"), "error")
-
+    
     while vehicle == 0 do
         vehicle = QBCore.Functions.GetClosestVehicle()
         if #(pos - GetEntityCoords(vehicle)) > 8 then
-        return end
+            QBCore.Functions.Notify(Lang:t("notify.vehclose"), "error")
+            return
+        end
     end
 
     if not IsEntityAVehicle(vehicle) then vehicle = nil end

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,7 +1,7 @@
 fx_version 'cerulean'
 game 'gta5'
 description 'QB-VehicleKeys'
-version '1.2.4'
+version '1.2.5'
 ui_page 'NUI/index.html'
 
 files {


### PR DESCRIPTION
added check if you are in the car to turn it on and off|

so if you are now outside the car, you cannot switch the car on and off with g, only with the keyfob
If you are in the car you can turn the engine on and off with g




If your PR is to fix an issue mention that issue here
yes


- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] yes
- Does your code fit the style guidelines? [yes/no] eys
- Does your PR fit the contribution guidelines? [yes/no] yes
