### PR TITLE
Add key removal on server side

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -36,6 +36,11 @@ RegisterNetEvent('qb-vehiclekeys:server:AcquireVehicleKeys', function(plate)
     GiveKeys(src, plate)
 end)
 
+RegisterNetEvent('qb-vehiclekeys:server:RemoveVehicleKeys', function(plate)
+    local src = source
+    RemoveKeys(src, plate)
+end)
+
 RegisterNetEvent('qb-vehiclekeys:server:breakLockpick', function(itemName)
     local Player = QBCore.Functions.GetPlayer(source)
     if not Player then return end


### PR DESCRIPTION
**Describe Pull request**
My code adds a server side remove keys event, because I don't think there is a proper way of removing keys from somebody.
The added event works just like the AcquireVehicleKeys event.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? no (but it's legit the same as the function above, so it should work)
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
