### PR TITLE
Vehiclekeys Patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # qb-vehiclekeys
 Vehicle Keys System For QB-Core
 
-# [video]
-[![Watch the video](https://media.discordapp.net/attachments/964009269408186448/1053708299553484850/image.png)](https://www.youtube.com/watch?v=7E9TXR3lXPI)
+# Vehicle Key NUI Preview
+[[Preview Here]](https://www.youtube.com/watch?v=7E9TXR3lXPI)
 
 
 # License

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,7 +1,7 @@
 fx_version 'cerulean'
 game 'gta5'
 description 'QB-VehicleKeys'
-version '1.2.5'
+version '1.3.0'
 ui_page 'NUI/index.html'
 
 files {

--- a/server/main.lua
+++ b/server/main.lua
@@ -41,7 +41,7 @@ RegisterNetEvent('qb-vehiclekeys:server:breakLockpick', function(itemName)
     if not Player then return end
     if not (itemName == "lockpick" or itemName == "advancedlockpick") then return end
     if Player.Functions.RemoveItem(itemName, 1) then
-            TriggerClientEvent("inventory:client:ItemBox", source, QBCore.Shared.Items[itemName], "remove")
+        TriggerClientEvent("inventory:client:ItemBox", source, QBCore.Shared.Items[itemName], "remove")
     end
 end)
 
@@ -83,6 +83,7 @@ function GiveKeys(id, plate)
     TriggerClientEvent('QBCore:Notify', id, Lang:t("notify.vgetkeys"))
     TriggerClientEvent('qb-vehiclekeys:client:AddKeys', id, plate)
 end
+exports('GiveKeys', GiveKeys)
 
 function RemoveKeys(id, plate)
     local citizenid = QBCore.Functions.GetPlayer(id).PlayerData.citizenid
@@ -93,6 +94,7 @@ function RemoveKeys(id, plate)
 
     TriggerClientEvent('qb-vehiclekeys:client:RemoveKeys', id, plate)
 end
+exports('RemoveKeys', RemoveKeys)
 
 function HasKeys(id, plate)
     local citizenid = QBCore.Functions.GetPlayer(id).PlayerData.citizenid
@@ -101,6 +103,7 @@ function HasKeys(id, plate)
     end
     return false
 end
+exports('HasKeys', HasKeys)
 
 QBCore.Commands.Add("givekeys", Lang:t("addcom.givekeys"), {{name = Lang:t("addcom.givekeys_id"), help = Lang:t("addcom.givekeys_id_help")}}, false, function(source, args)
 	local src = source


### PR DESCRIPTION
This vehiclekeys rework would patch maximum issues caused in the qb-vehiclekeys.

**Work in Client Side:**

> + Cleanedup Code
>      - Removed the Multiple functions like
>            -- addNoLockVehicles
>            -- removeNoLockVehicles
>            -- isBlacklistedVehicle
> 
> + Improved Code Readability
> + Added space and Tab Indications
> + Usage of Joaat
> + Usage of FreezeEntityPosition and SetVehicleUndriveable native to fixate the car while jacking

**Work in Server Side:**

> Added Exports for GiveKeys, RemoveKeys, HasKeys on server side

Edited Readme file since the preview image was missing