### PR TITLE
Add configurable lock/unlock animations & prop support

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,17 @@
 Config = {}
 
+-- Vehicle lock settings
+Config.LockToggleAnimation = {
+    AnimDict = 'anim@mp_player_intmenu@key_fob@',
+    Anim = 'fob_click',
+    Prop = 'prop_cuff_keys_01',
+    PropBone = 57005,
+    WaitTime = 500,
+}
+Config.LockAnimSound = "keys"
+Config.LockToggleSound = "lock"
+Config.LockToggleDist = 8.0
+
 -- NPC Vehicle Lock States
 Config.LockNPCDrivingCars = true -- Lock state for NPC cars being driven by NPCs [true = locked, false = unlocked]
 Config.LockNPCParkedCars = true -- Lock state for NPC parked cars [true = locked, false = unlocked]


### PR DESCRIPTION
**Describe Pull request**
Add configurable lock/unlock animation w/ prop support. New configuration parameters:
```lua
-- Vehicle lock settings
Config.LockToggleAnimation = {
    AnimDict = 'anim@mp_player_intmenu@key_fob@',
    Anim = 'fob_click',
    Prop = 'prop_cuff_keys_01',
    PropBone = 57005,
    WaitTime = 500,
}
Config.LockAnimSound = "keys"
Config.LockToggleSound = "lock"
Config.LockToggleDist = 8.0
```

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
