### PR TITLE
🔑 Optionally save acquired keys into DB

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -210,10 +210,12 @@ RegisterNetEvent('qb-vehiclekeys:client:AddKeys', function(plate)
             SetVehicleEngineOn(vehicle, false, false, false)
         end
     end
+    if Config.SaveInDB then TriggerServerEvent("qb-vehiclekeys:server:synckeys", KeysList) end
 end)
 
 RegisterNetEvent('qb-vehiclekeys:client:RemoveKeys', function(plate)
     KeysList[plate] = nil
+    if Config.SaveInDB then TriggerServerEvent("qb-vehiclekeys:server:synckeys", KeysList) end
 end)
 
 RegisterNetEvent('qb-vehiclekeys:client:ToggleEngine', function()

--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,8 @@
 Config = {}
 
+-- Key System Settings
+Config.SaveInDB = true -- Whether the own keys should save into database
+
 -- Vehicle lock settings
 Config.LockToggleAnimation = {
     AnimDict = 'anim@mp_player_intmenu@key_fob@',

--- a/server/main.lua
+++ b/server/main.lua
@@ -49,6 +49,12 @@ RegisterNetEvent('qb-vehiclekeys:server:setVehLockState', function(vehNetId, sta
     SetVehicleDoorsLocked(NetworkGetEntityFromNetworkId(vehNetId), state)
 end)
 
+RegisterServerEvent("qb-vehiclekeys:server:synckeys", function(KeyList)
+    if not Config.SaveInDB then return end
+    local Player = QBCore.Functions.GetPlayer(source)
+    Player.Functions.SetMetaData("VehKeys", KeyList)
+end)
+
 QBCore.Functions.CreateCallback('qb-vehiclekeys:server:GetVehicleKeys', function(source, cb)
     local Player = QBCore.Functions.GetPlayer(source)
     if not Player then return end
@@ -56,6 +62,11 @@ QBCore.Functions.CreateCallback('qb-vehiclekeys:server:GetVehicleKeys', function
     local keysList = {}
     for plate, citizenids in pairs (VehicleList) do
         if citizenids[citizenid] then
+            keysList[plate] = true
+        end
+    end
+    if Player.PlayerData.metadata["VehKeys"] and Config.SaveInDB then
+        for plate, value in Player.PlayerData.metadata["VehKeys"] do
             keysList[plate] = true
         end
     end


### PR DESCRIPTION
**Describe Pull request**
This PR makes so the aquired keys will be saved into DB so when the server restarts you will still have the keys you were given. This feature is optional and can be set in the Config file. The PR is made to answer this suggestion [[SUGGESTION] Database keys](https://github.com/qbcore-framework/qb-vehiclekeys/issues/253). I believe that is easier to make this into player metadata instead of a full new database table.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
